### PR TITLE
Fixed the broken read me example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # markov-words
-Node package to generate pronounceable words via Markov chains.
+Node package to generate pronounceable words via Markov chains.  In order to do this, the program requires statistics on frequency of letter combinations.  Here called stats.
 ```js
 var markov = require('markov-words');
 var result = markov(stats, 8); // generate an array of one 8 letter word
 ```
-To get the stats, use `word-stats`:
+To generate the stats from an array of example words, use the `calculateStats` function:
 ```js
-var stats = require('word-stats')(array_of_words);
-var result = require('markov-words').generate(stats, 8, 40); //40 8 letter words
+var markov_words = require('markov-words');
+var array_of_words = ["a", "aarau", "aardvark"] // etc.
+var stats = markov_words.calculateStats(array_of_words);
+var result = markov_words.generate(stats, 8, 40); //40 8 letter words
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ var result = markov(stats, 8); // generate an array of one 8 letter word
 ```
 To get the stats, use `word-stats`:
 ```js
-var stats = require('word-stats').calculate(array_of_words),
-    result = require('markov').generate(stats, 8, 40); //40 8 letter words
+var stats = require('word-stats')(array_of_words);
+var result = require('markov-words').generate(stats, 8, 40); //40 8 letter words
 ```


### PR DESCRIPTION
The old version of the read me suggested that you should use the "word-stats" npm package.  However, that package has now has either been change or moved.  If you run the code in the old read me, it tells you that word-stats does not have a function calculate.  In addition, the word-stats package does not produce the markov matrices that we need any way.  It only outputs statistics on individuals words pronunciation, syllable structure and emphasis.  The read me now tells you to use the calculateStats function from this package which does what you need.